### PR TITLE
[3] – Support multiple databases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,11 @@ SOCIAL_AUTH_ALLOWED_REDIRECT_URIS = 'http://localhost:3000','http://your-product
 # Djoser settings
 DOMAIN = 'localhost:5173'
 SITE_NAME = 'Survey and Polls backend'
+
+# Database settings
+DB_ENGINE = 'django.db.backends.<your db engine>' # NOTE: currently supported engines are: 'postgresql', 'mysql', 'sqlite3'
+DB_NAME = 'your db name'
+DB_USER = 'your db user'
+DB_PASSWORD = 'your db password'
+DB_HOST = 'your db host'
+DB_PORT = 'your db port'

--- a/config/settings.py
+++ b/config/settings.py
@@ -90,12 +90,12 @@ WSGI_APPLICATION = "config.wsgi.application"
 # Databse Configuration
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.mysql",
-        "NAME": "spapi",
-        "USER": "root",
-        "PASSWORD": "",
-        "HOST": "127.0.0.1",
-        "PORT": "3306"
+        "ENGINE": os.getenv("DB_ENGINE", "django.db.backends.mysql"),
+        "NAME": os.getenv("DB_NAME", "spapi"),
+        "USER": os.getenv("DB_USER", "root"),
+        "PASSWORD": os.getenv("DB_PASSWORD", ""),
+        "HOST": os.getenv("DB_HOST", "127.0.0.1"),
+        "PORT": os.getenv("DB_PORT", "3306"),
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ mysqlclient==2.2.4
 numpy==2.0.0
 oauthlib==3.2.2
 pandas==2.2.2
+psycopg2==2.9.9
 pycodestyle==2.12.0
 pycparser==2.22
 pyflakes==3.2.0


### PR DESCRIPTION
## Description

This PR aims to add support for multiple types of databases (MySQL, SQlite, PostgreSQL) via environment variables. By this addition, server can establish connection with various third party cloud databases as well.

 ### How to test
- Generate database connection configs from any cloud provider/local setup.
- Setup the database configs in `.env` file taking reference form `.env.example`.
- Test the connection either by logging into the database or running `python manage.py makemigrations`.
- If the above command runs without any error, database connection is established.

Tested on Supabase
Signed by Divij Sharma

CC @Sanchay-T 