### PR TITLE
[3] – Configure pytest and add tests for `core` app

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,6 +27,11 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd "mysqladmin ping --silent" --health-interval 10s --health-timeout 5s --health-retries 3
+    
+    env:
+      GOOGLE_OAUTH2_KEY: ${{ secrets.GOOGLE_OAUTH2_KEY }}
+      GOOGLE_OAUTH2_SECRET: ${{ secrets.GOOGLE_OAUTH2_SECRET }}
+      SOCIAL_AUTH_ALLOWED_REDIRECT_URIS: ${{ secrets.SOCIAL_AUTH_ALLOWED_REDIRECT_URIS }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,12 +20,10 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:9.0
         env:
           MYSQL_DATABASE: spapi
-          MYSQL_USER: root
-          MYSQL_PASSWORD: ""
-          MYSQL_ROOT_PASSWORD: ""
+          MYSQL_ROOT_PASSWORD: "password"
         ports:
           - 3306:3306
         options: --health-cmd "mysqladmin ping --silent" --health-interval 10s --health-timeout 5s --health-retries 3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,58 @@
+# Brief: pytest.yml testing action
+
+# Description: GitHub Actions workflow to run tests using pytest.
+
+# Author: Divij Sharma <divijs75@gmail.com>
+
+name: Test with pytest
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: spapi
+          MYSQL_USER: root
+          MYSQL_PASSWORD: ""
+          MYSQL_ROOT_PASSWORD: ""
+        ports:
+          - 3306:3306
+        options: --health-cmd "mysqladmin ping --silent" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Wait for MySQL to be ready
+      run: |
+        until mysqladmin ping --host=127.0.0.1 --port=3306 --silent; do
+          echo 'Waiting for MySQL...'
+          sleep 5
+        done
+
+    - name: Run migrations
+      run: python manage.py migrate
+
+    - name: Run tests
+      run: pytest --disable-warnings

--- a/config/settings.py
+++ b/config/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "corsheaders",
+    "drf_yasg",
     "djoser",
     "social_django",
     "rest_framework",

--- a/config/settings.py
+++ b/config/settings.py
@@ -131,6 +131,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 
 STATIC_URL = "static/"
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # Default primary key field type
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -67,7 +67,7 @@ MIDDLEWARE = [
 ROOT_URLCONF = "config.urls"
 
 # Get the CORS allowed origins from the environment variable
-CORS_ALLOWED_ORIGINS = os.environ.get('CORS_ALLOWED_ORIGINS', '').split(',')
+CORS_ALLOWED_ORIGINS = os.environ.get('CORS_ALLOWED_ORIGINS', 'http://localhost:3000').split(',')
 
 # Template settings
 TEMPLATES = [
@@ -95,7 +95,7 @@ DATABASES = {
         "ENGINE": os.getenv("DB_ENGINE", "django.db.backends.mysql"),
         "NAME": os.getenv("DB_NAME", "spapi"),
         "USER": os.getenv("DB_USER", "root"),
-        "PASSWORD": os.getenv("DB_PASSWORD", ""),
+        "PASSWORD": os.getenv("DB_PASSWORD", "password"),
         "HOST": os.getenv("DB_HOST", "127.0.0.1"),
         "PORT": os.getenv("DB_PORT", "3306"),
     }

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,7 +7,23 @@ Author: Divij Sharma <divijs75@gmail.com>
 """
 import os
 from django.contrib import admin
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 from django.urls import path, include
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Survey and Polling API",
+      default_version='v1',
+      description="Survey and Polling backend APIs swagger documentation",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="contact@yourapi.local"),
+      license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
 
 API_BASE_PATH = "api/v1/"
 
@@ -15,6 +31,7 @@ urlpatterns = [
     path(f"{API_BASE_PATH}auth/", include("core.urls")),
     path(f"{API_BASE_PATH}live/", include("live.urls")),
     path(f"{API_BASE_PATH}data/", include("data.urls")),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]
 
 if os.environ.get("ENV") == "development":

--- a/core/tests.py
+++ b/core/tests.py
@@ -103,7 +103,7 @@ def test_user_deactivation(api_client, admin_user):
         'first_name': 'Test',
         'last_name': 'User'
     }
-    response = api_client.post(url, data, format='json')
+    api_client.post(url, data, format='json')
     user = User.objects.get(username='testuser2')
     assert user.is_deactivated is False
     assert user.is_active is False

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,0 +1,120 @@
+"""
+Brief: Django tests.py file.
+
+Description: This file contains the tests for the Django core app.
+
+Author: Divij Sharma <divijs75@gmail.com>
+"""
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user():
+    return User.objects.create_user(
+        username='testuser',
+        email='testuser@example.com',
+        password='qwerty@12345',
+        first_name='Test',
+        last_name='User'
+    )
+
+
+@pytest.fixture
+def admin_user():
+    user = User.objects.create_superuser(
+        username='adminuser',
+        email='adminuser@example.com',
+        password='qwerty@12345',
+        first_name='Admin',
+        last_name='User'
+    )
+    return user
+
+
+@pytest.mark.django_db
+def test_user_creation(api_client):
+    url = reverse('user-list')
+    data = {
+        'first_name': 'New',
+        'last_name': 'User',
+        'email': 'newuser@example.com',
+        'username': 'newuser',
+        'password': 'qwerty@12345'
+    }
+    response = api_client.post(url, data, format='json')
+    assert response.status_code == status.HTTP_201_CREATED
+    assert User.objects.filter(username='newuser').exists()
+
+
+@pytest.mark.django_db
+def test_check_username_exists(api_client, user):
+    url = reverse('exists')
+    response = api_client.post(url, {'username': 'testuser'}, format='json')
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {'username_exists': True}
+
+    response = api_client.post(url, {'username': 'nonexistentuser'}, format='json')
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {'username_exists': False}
+
+
+@pytest.mark.django_db
+def test_home(api_client):
+    url = reverse('home')
+    response = api_client.get(url)
+    print(response.data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_custom_token_obtain(api_client, user):
+    user.is_active = True
+    user.save()
+    url = reverse('custom_jwt_create')
+    data = {
+        'username': 'testuser',
+        'password': 'qwerty@12345'
+    }
+    response = api_client.post(url, data, format='json')
+    assert response.status_code == status.HTTP_200_OK
+    assert 'access' in response.json()
+    assert 'refresh' in response.json()
+
+
+@pytest.mark.django_db
+def test_user_deactivation(api_client, admin_user):
+    url = reverse('user-list')
+    data = {
+        'username': 'testuser2',
+        'email': 'testuser2@example.com',
+        'password': 'qwerty@12345',
+        'first_name': 'Test',
+        'last_name': 'User'
+    }
+    response = api_client.post(url, data, format='json')
+    user = User.objects.get(username='testuser2')
+    assert user.is_deactivated is False
+    assert user.is_active is False
+
+
+@pytest.mark.django_db
+def test_user_activation(api_client, user):
+    user.is_active = True
+    user.is_deactivated = True
+    user.save()
+    print(user.is_deactivated)
+    print(user.is_active)
+    assert user.is_deactivated is True
+    assert user.is_active is True

--- a/documentation/openapi.yaml
+++ b/documentation/openapi.yaml
@@ -1,0 +1,615 @@
+openapi: 3.1.0
+info:
+  title: A2I
+  version: 1.0.0
+servers:
+  - url: http://localhost:8000
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    noauthAuth:
+      type: http
+      scheme: noauth
+tags:
+  - name: Auth
+  - name: Live
+  - name: Data
+paths:
+  /auth/jwt/create:
+    post:
+      tags:
+        - Auth
+      summary: 'Auth: Create JWT'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                username: admin
+                password: admin
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/status:
+    get:
+      tags:
+        - Auth
+      summary: 'Auth: Home'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users:
+    get:
+      tags:
+        - Auth
+      summary: 'Auth: Get Users'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users/:
+    post:
+      tags:
+        - Auth
+      summary: 'Auth: Create User'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                first_name: System
+                last_name: Admin
+                email: sysadmin@a2i.com
+                username: sysadmin
+                password: '#skadfnuhDSFilh3sad'
+      security:
+        - noauthAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users/resend_activation/:
+    post:
+      tags:
+        - Auth
+      summary: 'Auth: Resend Activation'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                email: sysadmin@a2i.com
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users/activation/:
+    post:
+      tags:
+        - Auth
+      summary: 'Auth: User Activation'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                uid: Mw
+                token: c9ay4l-19122c9d8edf47843e6e74aaabbb2e7b
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users/me/:
+    patch:
+      tags:
+        - Auth
+      summary: 'Auth: Edit/Get Users'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                first_name: System
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users/reset_password/:
+    post:
+      tags:
+        - Auth
+      summary: 'Auth: Reset pass mail'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                email: sysadmin@a2i.com
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users/reset_password_confirm/:
+    post:
+      tags:
+        - Auth
+      summary: 'Auth: Create new password'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                uid: MQ
+                token: c9iaoz-7b058e4e70ae4afe07efd8fab944039c
+                new_password: '#skadfnuhDSFilh3sad'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users/reset_username/:
+    post:
+      tags:
+        - Auth
+      summary: 'Auth: Reset Username'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                email: sysadmin@a2i.com
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/users/reset_username_confirm/:
+    post:
+      tags:
+        - Auth
+      summary: 'Auth: Reset Username confirm'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                uid: MQ
+                token: c9iayh-249e3ff1a89f01103819fbdf098bd159
+                new_username: sysadminhead
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /live/instance/:
+    get:
+      tags:
+        - Live
+      summary: 'Live: Get Instance'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Live
+      summary: 'Live: Create Instance'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                name: Test Instance
+                description: Test Instance
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /live/instance/353fc15d70534689/:
+    patch:
+      tags:
+        - Live
+      summary: 'Live: Edit/Delete Instance'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                instance_auth_type: 2
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /live/instance/info:
+    post:
+      tags:
+        - Live
+      summary: 'Live: Get Status'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                hash: ce7f9dc562024f67
+      security:
+        - noauthAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /live/1849b35954104c3c/google-oauth2/:
+    get:
+      tags:
+        - Live
+      summary: 'Live: Get redirect URI'
+      parameters:
+        - name: redirect_uri
+          in: query
+          schema:
+            type: string
+          example: http://localhost:3000
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Live
+      summary: 'Live: Process request'
+      requestBody:
+        content: {}
+      parameters:
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: state
+          in: query
+          schema:
+            type: string
+          example: CWwpMgzvwf5Qd4ErvPbrpLuYTTAzlrpS
+        - name: code
+          in: query
+          schema:
+            type: string
+          example: >-
+            4/0ATx3LY64IIZUCc5MO_ZMfm9uzDyT_Y2Rd5vEE3-ihxWKKwpkTMoo7wEQe-fCJQbe7L1IBw
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /live/instance/CSV/1849b35954104c3c/:
+    get:
+      tags:
+        - Live
+      summary: 'Live: Get Social users (CSV/JSON)'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Live
+      summary: 'Live: Create Social Users (CSV/JSON)'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                first_name:
+                  type: string
+                  example: firstname
+                last_name:
+                  type: string
+                  example: lastname
+                username:
+                  type: string
+                  example: email
+                password:
+                  type: string
+                  example: password
+                file:
+                  type: string
+                  format: binary
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /live/instance/CSV/1849b35954104c3c/temp@gmail.com:
+    patch:
+      tags:
+        - Live
+      summary: 'Live: Edit Social users (CSV/JSON)'
+      requestBody:
+        content: {}
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /live/instance/1849b35954104c3c/login:
+    post:
+      tags:
+        - Live
+      summary: 'Live: Create social JWT token'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                username: socialuser1@somedomain.com
+                password: password
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /live/instance/ORG/fefb35d2e0e147a6/download:
+    get:
+      tags:
+        - Live
+      summary: 'Live: Get Social users (ORG)'
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: format
+          in: query
+          schema:
+            type: string
+          example: json
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /data/91c036740d474e94/form/:
+    post:
+      tags:
+        - Data
+      summary: 'Data: Post From'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                title: Sample Survey
+                fields:
+                  - title: Short text question
+                    type: short-text
+                    required: true
+                  - title: long text question
+                    required: true
+                    type: long-text
+                  - title: Number question
+                    required: false
+                    type: number
+                  - title: Multioption single answer
+                    required: true
+                    options:
+                      - a
+                      - b
+                      - c
+                      - d
+                    type: multioption-singleanswer
+                  - title: 'Multioption multi answer '
+                    required: true
+                    options:
+                      - a
+                      - b
+                      - c
+                      - d
+                    type: multioption-multianswer
+                  - title: File upload
+                    required: true
+                    type: file
+                    accepted:
+                      - jpg
+                      - png
+                      - jpeg
+                      - pdf
+                      - txt
+                endMessage: 'thanks for submitting '
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    get:
+      tags:
+        - Data
+      summary: 'Data: Get Form'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /data/91c036740d474e94/form/2:
+    patch:
+      tags:
+        - Data
+      summary: 'Data: Edit Form'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                title: Changed title
+                description: Changed Desceription
+                endMessage: Changed end message
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /data/form/5/question:
+    post:
+      tags:
+        - Data
+      summary: 'Data: Post Form Questions'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                title: custon question
+                type: number
+                required: true
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /data/91c036740d474e94/form/3/question/17:
+    patch:
+      tags:
+        - Data
+      summary: 'Data: Edit Form Questions Copy'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                required: false
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /data/91c036740d474e94/voter/get-data:
+    get:
+      tags:
+        - Data
+      summary: 'Data: Get data as a user'
+      security:
+        - noauthAuth: []
+      parameters:
+        - name: access
+          in: query
+          schema:
+            type: string
+          example: '{{social_token}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /data/91c036740d474e94/voter/post-data:
+    post:
+      tags:
+        - Data
+      summary: 'Data: Post data as user'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                answers:
+                  - id: '16'
+                    value: some value
+                  - id: '17'
+                    value: some value
+      security:
+        - noauthAuth: []
+      parameters:
+        - name: access
+          in: query
+          schema:
+            type: string
+          example: '{{social_token}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /data/91c036740d474e94/responses:
+    get:
+      tags:
+        - Data
+      summary: 'Data: Get responses'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /data/91c036740d474e94/responses/1:
+    delete:
+      tags:
+        - Data
+      summary: 'Data: Delete responses'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+# Brief: pytest config for the API
+
+# Description: This file contains the configuration for pytest to run the tests in the API.
+
+# Author: Divij Sharma <divijs75@gmail.com>
+
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+python_files = tests.py test_*.py *_tests.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ drf-yasg==1.21.7
 flake8==7.1.0
 idna==3.7
 inflection==0.5.1
+iniconfig==2.0.0
 jsonfield==3.1.0
 jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
@@ -26,11 +27,14 @@ numpy==2.0.0
 oauthlib==3.2.2
 packaging==24.1
 pandas==2.2.2
+pluggy==1.5.0
 psycopg2==2.9.9
 pycodestyle==2.12.0
 pycparser==2.22
 pyflakes==3.2.0
 PyJWT==2.8.0
+pytest==8.3.2
+pytest-django==4.9.0
 python-dateutil==2.9.0.post0
 python-decouple==3.8
 python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ djangorestframework-simplejwt==5.3.1
 djoser==2.2.3
 drf-spectacular==0.27.2
 drf-spectacular-sidecar==2024.7.1
+drf-yasg==1.21.7
 flake8==7.1.0
 idna==3.7
 inflection==0.5.1
@@ -23,6 +24,7 @@ mccabe==0.7.0
 mysqlclient==2.2.4
 numpy==2.0.0
 oauthlib==3.2.2
+packaging==24.1
 pandas==2.2.2
 psycopg2==2.9.9
 pycodestyle==2.12.0


### PR DESCRIPTION
## Description

This PR aims to add unit testing suite (`pytest`) for unit testing purposes as well as add tests for the `core` app. The process is automated in CI using GitHub Actions and a `pytest.yml` config file.

 ### How to test
- Clone the code, and start the database.
- Run `pytest` in the root directory to test the suite.

Signed by Divij Sharma

CC @Sanchay-T 